### PR TITLE
Set exact version for miniquad

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ mint = "0.5"
 cgmath = { version = "0.17", features = ["mint"] }
 twox-hash = "=1.5.0"    # necessary to force a version of rand < 0.8 to avoid getrandom
 glyph_brush = "0.7"
-miniquad = "0.3.13"
+miniquad = "=0.3.13"
 image = { version = "0.22", default-features = false, features = ["png_codec"] }
 serde = "1"
 serde_derive = "1"


### PR DESCRIPTION
The "js_bundle.js" file in index.html expects the version for miniquad to be exactly 0.3.13. This change enforces that.